### PR TITLE
Update gcc

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -20,7 +20,7 @@
         packages = with pkgs; [
           pros-cli-nix.packages.${system}.default
           clang-tools
-          gcc-arm-embedded-10
+          gcc-arm-embedded-13
         ];
       };
     });


### PR DESCRIPTION
lemlib and pros 4.2 uses c++ 23 so it is needed 